### PR TITLE
Use `Logger.warning/1` when available

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,13 @@ import Config
 
 config :logger,
   handle_otp_reports: true,
-  handle_sasl_reports: true,
-  level: :warn
+  handle_sasl_reports: true
+
+# TODO: remove when we depend on Elixir ~> 1.11.
+if macro_exported?(Logger, :warning, 1) do
+  config :logger, level: :warning
+else
+  config :logger, level: :warn
+end
 
 config :sasl, :sasl_error_logger, false

--- a/lib/worker/rabbit_connection.ex
+++ b/lib/worker/rabbit_connection.ex
@@ -230,7 +230,9 @@ defmodule ExRabbitPool.Worker.RabbitConnection do
         {:EXIT, pid, reason},
         %{channels: channels, connection: conn, adapter: adapter, monitors: monitors} = state
       ) do
-    Logger.warn("[Rabbit] channel lost reason: #{inspect(reason)}")
+    # TODO: remove when we depend on Elixir ~> 1.11.
+    log_warning("[Rabbit] channel lost reason: #{inspect(reason)}")
+
     # don't start a new channel if crashed channel doesn't belongs to the pool
     # anymore, this can happen when a channel crashed or is closed when a client holds it
     # so we get an `:EXIT` message and a `:checkin_channel` message in no given
@@ -381,5 +383,12 @@ defmodule ExRabbitPool.Worker.RabbitConnection do
 
   defp find_monitor(monitors, ref) do
     Enum.find(monitors, fn {_pid, monitor_ref} -> monitor_ref == ref end)
+  end
+
+  # TODO: remove when we depend on Elixir ~> 1.11.
+  if macro_exported?(Logger, :warning, 1) do
+    defp log_warning(message), do: Logger.warning(message)
+  else
+    defp log_warning(message), do: Logger.warn(message)
   end
 end

--- a/test/integration/consumer_test.exs
+++ b/test/integration/consumer_test.exs
@@ -14,12 +14,22 @@ defmodule ExRabbitPool.ConsumerTest do
 
     def setup_channel(%{adapter: adapter, config: config}, channel) do
       config = Keyword.get(config, :options, [])
-      Logger.warn("Setting up channel with options: #{inspect(config)}")
+
+      # TODO: remove when we depend on Elixir ~> 1.11.
+      log_warning("Setting up channel with options: #{inspect(config)}")
+
       adapter.qos(channel, config)
     end
 
     def basic_deliver(%{adapter: adapter, channel: channel}, _payload, %{delivery_tag: tag}) do
       :ok = adapter.ack(channel, tag)
+    end
+
+    # TODO: remove when we depend on Elixir ~> 1.11.
+    if macro_exported?(Logger, :warning, 1) do
+      defp log_warning(message), do: Logger.warning(message)
+    else
+      defp log_warning(message), do: Logger.warn(message)
     end
   end
 
@@ -28,12 +38,22 @@ defmodule ExRabbitPool.ConsumerTest do
 
     def setup_channel(%{adapter: adapter, config: config}, channel) do
       config = Keyword.get(config, :options, [])
-      Logger.warn("Setting up channel with options: #{inspect(config)}")
+
+      # TODO: remove when we depend on Elixir ~> 1.11.
+      log_warning("Setting up channel with options: #{inspect(config)}")
+
       adapter.qos(channel, config)
     end
 
     def basic_deliver(_state, _payload, _meta) do
       :ok
+    end
+
+    # TODO: remove when we depend on Elixir ~> 1.11.
+    if macro_exported?(Logger, :warning, 1) do
+      defp log_warning(message), do: Logger.warning(message)
+    else
+      defp log_warning(message), do: Logger.warn(message)
     end
   end
 

--- a/test/worker/rabbit_connection_test.exs
+++ b/test/worker/rabbit_connection_test.exs
@@ -33,7 +33,7 @@ defmodule ExRabbitPool.Worker.RabbitConnectionTest do
   test "adds record to monitors table when checking out a channel", %{config: config} do
     new_config = Keyword.update!(config, :channels, fn _ -> 1 end)
     pid = start_supervised!({ConnWorker, new_config})
-    assert {:ok, %{pid: pid} = channel} = ConnWorker.checkout_channel(pid)
+    assert {:ok, %{pid: pid} = _channel} = ConnWorker.checkout_channel(pid)
     %{monitors: monitors} = ConnWorker.state(pid)
     assert Map.get(monitors, pid) |> is_reference()
   end


### PR DESCRIPTION
Uses `Logger.warning/1` instead of `Logger.warn/1` for Elixir 1.11+.